### PR TITLE
Fix to docs bugs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,8 @@ conf = ConfigParser()
 
 conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))
+#Trevor fix here for docs:
+setup_cfg['name'] = 'jazzhands'
 
 # -- General configuration ----------------------------------------------------
 


### PR DESCRIPTION
For future reference: you can change the default branch on ReadTheDocs to make sure the docs build correctly before merging into main.

This fix changes `conf.py` to have the correct package name when installing.